### PR TITLE
Add support for a --dry-run flag, to stop retweets and instead log matches to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ module.exports = {
 ## Running the tests
 
 Simply run `npm test`
+
+## Disabling retweets
+
+Retweets can be disabled for testing purposes by using the argument `--dry-run`, e.g. `node vegassist.js --dry-run`. In dry run mode, matching tweets will be logged to the console but not retweeted.

--- a/vegassist.js
+++ b/vegassist.js
@@ -8,9 +8,18 @@ var T = new Twit(settings.CREDS);
 var stream = T.stream('statuses/filter', { track: 'vegan' });
 // Load filters from all files in the filters directory
 var filter = new TweetFilter('filters', settings.FILTERED_TERMS);
+// Run with option '--dry-run' to disable retweeting and instead log matches to console
+var isDryRun = process.argv[2] === '--dry-run';
 
+stream.on('connected', function (response) {
+    console.log("Connected to Twitter" + (isDryRun ? " (dry run, will not retweet matches)" : ", looking for matching tweets..."))
+})
 stream.on('tweet', function(tweet) {
     if (filter.matches(tweet)) {
+        if (isDryRun) {
+            console.log(tweet.id_str + ' : ' + tweet.user.screen_name + ' : ' + tweet.text)
+            return;
+        }
         // positive match; let's retweet!
         T.post('statuses/retweet/:id', {id: tweet.id_str}, function(err, data, response) {
             if (err) {


### PR DESCRIPTION
Useful for testing filters using the real Twitter stream
