### PR TITLE
Dutch filters

### DIFF
--- a/filters/dutch.js
+++ b/filters/dutch.js
@@ -5,4 +5,13 @@ module.exports = [
     'ik wil vegan worden',
     'ik wil veganist zijn',
     'ik wil vegan zijn',
+//  'help me vegetarier te worden',
+//  'help me vegetariër te worden',
+//  'help me vegetarisch te worden',
+//  'ik wil vegetarier worden',
+//  'ik wil vegetariër worden',
+//  'ik wil vegetarisch worden',
+//  'ik wil vegetarier zijn',
+//  'ik wil vegetariër zijn',
+//  'ik wil vegetarisch zijn',
 ]

--- a/filters/dutch.js
+++ b/filters/dutch.js
@@ -1,0 +1,8 @@
+module.exports = [
+    'help me veganist te worden',
+    'help me vegan te worden',
+    'ik wil veganist worden',
+    'ik wil vegan worden',
+    'ik wil veganist zijn',
+    'ik wil vegan zijn',
+]


### PR DESCRIPTION
Added Dutch versions of the phrases. Also added vegetarian versions, but left those commented out.

Not sure what the plan is with languages, but I decided to make a pull request anyways. Maybe filters other than the default should be disabled by default? That way merging in more languages won't affect @plorry's instance of the bot.
