### PR TITLE
Exclude tweets that are retweets

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -46,7 +46,11 @@ TweetFilter.prototype.textMatchesAnyFilters = function(text) {
     return false;
 }
 
-TweetFilter.prototype.tweetWasRetweeted = function(tweet) {
+TweetFilter.prototype.tweetIsARetweet = function(tweet) {
+    return tweet.hasOwnProperty('retweeted_status');
+}
+
+TweetFilter.prototype.tweetWasRetweetedByMe = function(tweet) {
     return tweet.retweeted === true;
 }
 
@@ -62,7 +66,7 @@ TweetFilter.prototype.tweetIsPrivateConvo = function(tweet) {
 }
 
 TweetFilter.prototype.tweetIsEligable = function(tweet) {
-    return !this.tweetWasRetweeted(tweet) && !this.tweetContainsExcludedTerms(tweet) && !this.tweetIsPrivateConvo(tweet);
+    return !this.tweetWasRetweetedByMe(tweet) && !this.tweetIsARetweet(tweet) && !this.tweetContainsExcludedTerms(tweet) && !this.tweetIsPrivateConvo(tweet);
 }
 
 TweetFilter.prototype.matches = function(tweet_or_text) {

--- a/test/test-filter.js
+++ b/test/test-filter.js
@@ -67,19 +67,34 @@ exports.falsePositives = function(test) {
     test.done();
 };
 
-exports.retweeted = function(test) {
-    var retweetedTweet = {retweeted: true, text: "", user: {description: "", name: "", screen_name: ""}};
-    test.ok(!filter.matches(retweetedTweet), "Filter should not match retweeted tweets");
+exports.retweetedByMe = function(test) {
+    var retweetedTweet = {retweeted: true, text: "I want to go vegan", user: {description: "", name: "", screen_name: ""}};
+    test.ok(!filter.matches(retweetedTweet), "Filter should not match tweets that have been retweeted by the authed user");
+    retweetedTweet.retweeted = false;
+    test.ok(filter.matches(retweetedTweet), "Filter should match tweets that haven't been retweeted by the authed user");
+    test.done();
+}
+
+exports.retweet = function(test) {
+    var retweetTweet = {retweeted: false, retweeted_status: {}, text: "I want to go vegan", user: {description: "", name: "", screen_name: ""}};
+    test.ok(!filter.matches(retweetTweet), "Filter should not match tweets that are retweets");
+    delete retweetTweet.retweeted_status;
+    test.ok(filter.matches(retweetTweet), "Filter should match tweets that aren't retweets");
     test.done();
 }
 
 exports.reply = function(test) {
     var replyTweet = {retweeted: false, text: "@someone I want to go vegan", user: {description: "", name: "", screen_name: ""}};
     test.ok(!filter.matches(replyTweet), "Filter should not match @reply tweets");
+    replyTweet.text = "I want to go vegan";
+    test.ok(filter.matches(replyTweet), "Filter should match tweets that aren't @replies");
     test.done();
 }
 
 exports.excludedTerms = function(test) {
+    var unexcludedTweet = {retweeted: false, text: "I want to go vegan", user: {description: "", name: "", screen_name: ""}};
+    test.ok(filter.matches(unexcludedTweet), "Filter should match tweets that don't have any excluded terms in their bio/name/username");
+
     var excludedBioTweet = {retweeted: false, text: "I want to go vegan", user: {description: "Something and excludeme", name: "", screen_name: ""}};
     var excludedNameTweet = {retweeted: false, text: "I want to go vegan", user: {description: "", name: "EXCLUDEME", screen_name: ""}};
     var excludedScreenNameTweet = {retweeted: false, text: "I want to go vegan", user: {description: "", name: "", screen_name: "excludeme"}};


### PR DESCRIPTION
Also improve the other tweet eligability test cases by making sure they are testing what they should be (confirm that the tweet would match otherwise)

---

Prompted by this being retweeted: https://twitter.com/truthmakessad/status/658326020836184064

I think what happened is that Emily Moran retweeted it, which changed the text of the retweet to `RT @truthmakesmesad: @BiteSizeVegan Your videos already helped me very much especially with explaining my parents why I want to be vegan :)`, and therefore it didn't get excluded by the `tweet.text[0] === '@'` check when it should have.

This PR makes the filter exclude any tweets that are retweets (meaning any tweet that has a `retweeted_status` property)

This is only one way to solve this (assuming it should be solved). The other way would be to check for `retweeted_status`, and, if it exists, apply the filters on that instead of the retweet (which would have then also excluded it based on the `@` as the first character). Note that this method would potentially allow really old tweets to be caught by VegAssist, as a user could potentially retweet a matching tweet from any time and VegAssist would still accept it.

Relevant API docs:
- https://dev.twitter.com/overview/api/tweets (see `retweeted_status`)
- https://dev.twitter.com/overview/api/entities-in-twitter-objects#retweets
