### PR TITLE
Force "I should go/be vegan" phrase to be at the start of a tweet

### DIFF
--- a/filters/english.js
+++ b/filters/english.js
@@ -17,7 +17,8 @@ var robustRegex = function(regexStr, flags) {
 module.exports = [
     robustRegex( "help me (be( a)?|become( a)?|go) #?vegan" ),
     robustRegex( "i (" + adverbsRegexSet + ")? ?(want to|wanna|would like to) (be( a)?|become( a)?|go) #?vegan" ),
-    robustRegex( "i (" + adverbsRegexSet + ")? ?(should) (go|be) #?vegan" ),
+    // forcing this to be at the start of the tweet is a simple hack for excluding things like "don't tell me I should go vegan"
+    robustRegex( "^(i think)? ?i (" + adverbsRegexSet + ")? ?(should) (go|be) #?vegan" ),
     robustRegex( "i (" + adverbsRegexSet + ")? ?(will|do)? ?(need|want) help (going|becoming( a)?|being( a)?|staying( a)?) #?vegan" ),
     robustRegex( "i (" + adverbsRegexSet + ")? ?(want to|wanna|would like to|should) (try) (going|becoming( a)?|being( a)?) #?vegan" ),
     robustRegex( "i('| a)?m (considering|thinking (about|of)|mulling over) (going|becoming( a)?|being( a)?) #?vegan" ),

--- a/test/test-filter.js
+++ b/test/test-filter.js
@@ -46,6 +46,7 @@ var matches = [
 var falsePositives = [
     "I do not want to go vegan",
     "I should be a vegan", // this phrasing more than likely isn't about going vegan long-term (e.g. I should be a vegan for Halloween)
+    "Don't tell me I should go vegan",
 ];
 
 exports.matches = function(test) {


### PR DESCRIPTION
- A simple hack for excluding things like "don't tell me I should go vegan"
- Fixes #12

---

As I said in #12, this is just one possible fix, and maybe not the best. It'll be effective, but it will also exclude some tweets that it shouldn't.
