### PR TITLE
Match logging + syntax error fix

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -38,9 +38,9 @@ TweetFilter.isPhraseQuoted = function(phrase, startIndex, fullText) {
 TweetFilter.getMatch = function(text, filter, lastIndex) {
     lastIndex = lastIndex || 0;
     if (typeof filter == "string") {
-        var indexStart = text.toLowerCase().indexOf(filter, lastIndex);
+        var indexStart = text.toLowerCase().indexOf(filter.toLowerCase(), lastIndex);
         if (indexStart > -1) {
-            return { [0]: text.substring(indexStart, indexStart + text.length), index: indexStart }
+            return { 0: text.substring(indexStart, indexStart + filter.length), index: indexStart }
         }
     }
     else if (filter instanceof RegExp) {
@@ -58,7 +58,7 @@ TweetFilter.getAllMatches = function(text, filter) {
         var nextIndex = 0;
         var match;
         while (match = TweetFilter.getMatch(text, filter, nextIndex)) {
-            nextIndex = match.index + match[0].length + 1;
+            nextIndex = match.index + match[0].length;
             matches.push(match);
         }
     }

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -50,6 +50,8 @@ TweetFilter.getMatch = function(text, filter, lastIndex) {
 }
 
 // returns an array of matches (see getMatch)
+// adds a 'filter' property to each match containing
+// the string/regex filter
 TweetFilter.getAllMatches = function(text, filter) {
     var matches = [];
     if (typeof filter == "string") {
@@ -72,49 +74,33 @@ TweetFilter.getAllMatches = function(text, filter) {
             }
         }
     }
-    return matches;
+    return matches.map(function(match) {
+        match.filter = filter;
+        return match;
+    });
 }
 
 // returns an array of matches that were matched by any filter in the filter list
+// adds a 'filterList' property to each match containing the filter list used
 TweetFilter.prototype.getMatchesForFilterList = function(text, filter_name) {
     var matches = [];
     this.filters[filter_name].forEach(function(filter) {
         matches = matches.concat(TweetFilter.getAllMatches(text, filter));
     });
-    return matches;
-}
-
-// returns an associative array of filter_name => [matches] pairs
-// filters without matches will not have a key defined
-TweetFilter.prototype.getMatchesForAllFilters = function(text) {
-    var allFilterMatches = {}
-    for (var filter_name in this.filters) {
-        var filterMatches = this.getMatchesForFilterList(text, filter_name);
-        if (filterMatches.length > 0) {
-            allFilterMatches[filter_name] = filterMatches;
-        }
-    }
-    return allFilterMatches;
-}
-
-// static because it doesn't use any instance variables
-TweetFilter.textMatchesFilter = function(text, filter) {
-    return TweetFilter.getMatch(text, filter) !== null;
-}
-
-TweetFilter.prototype.textMatchesFilterList = function(text, filter_name) {
-    return this.filters[filter_name].some(function(filter) {
-        return TweetFilter.textMatchesFilter(text, filter);
+    return matches.map(function(match) {
+        match.filterList = filter_name;
+        return match;
     });
 }
 
-TweetFilter.prototype.textMatchesAnyFilters = function(text) {
+// returns an array of matches that were matched by any filter
+TweetFilter.prototype.getMatchesForAllFilters = function(text) {
+    var allFilterMatches = []
     for (var filter_name in this.filters) {
-        if (this.textMatchesFilterList(text, filter_name)) {
-            return true;
-        }
+        var filterMatches = this.getMatchesForFilterList(text, filter_name);
+        allFilterMatches = allFilterMatches.concat(filterMatches);
     }
-    return false;
+    return allFilterMatches;
 }
 
 TweetFilter.prototype.tweetIsARetweet = function(tweet) {
@@ -140,6 +126,7 @@ TweetFilter.prototype.tweetIsEligable = function(tweet) {
     return !this.tweetWasRetweetedByMe(tweet) && !this.tweetIsARetweet(tweet) && !this.tweetContainsExcludedTerms(tweet) && !this.tweetIsPrivateConvo(tweet);
 }
 
+// returns an array containing all matches found or false if none were found
 TweetFilter.prototype.matches = function(tweet_or_text) {
     var isTweet = typeof tweet_or_text !== 'string'
 
@@ -147,17 +134,12 @@ TweetFilter.prototype.matches = function(tweet_or_text) {
         return false;
 
     var text = !isTweet ? tweet_or_text : tweet_or_text.text;
-    var matches = this.getMatchesForAllFilters(text);
+    var matches = this.getMatchesForAllFilters(text).filter(function(match) {
+        var isQuoted = TweetFilter.isPhraseQuoted(match[0], match.index, text);
+        return !isQuoted;
+    });
 
-    for (var filter_name in matches) {
-        var filterMatches = matches[filter_name];
-        return filterMatches.some(function(match) {
-            var isQuoted = TweetFilter.isPhraseQuoted(match[0], match.index, text);
-            return !isQuoted;
-        });
-    }
-
-    return false;
+    return matches.length > 0 ? matches : false;
 }
 
 module.exports = TweetFilter;

--- a/test/test-filter.js
+++ b/test/test-filter.js
@@ -110,3 +110,11 @@ exports.excludedTerms = function(test) {
     test.ok(!filter.matches(excludedScreenNameTweet), "Filter should not match tweets from users with excluded terms in their screen name");
     test.done();
 }
+
+exports.numMatches = function(test) {
+    test.equal(TweetFilter.getAllMatches("testtesttest", "test").length, 3, "Plain string matching matches all instances of the pattern");
+    test.equal(TweetFilter.getAllMatches("testtestTEST", "Test").length, 3, "Plain string matching is case sensitive");
+    test.equal(TweetFilter.getAllMatches("testtestTEST", /test/i).length, 1, "Regex without the global flag only matches the first match");
+    test.equal(TweetFilter.getAllMatches("testtestTEST", /test/gi).length, 3, "Regex with the global flag matches all instances of the pattern");
+    test.done();
+}


### PR DESCRIPTION
The important bits: 
- Log to either ./matches.json or ./matches.dry-run.json
- Each tweet/match pair will be a separate line of json
- Fix plain string matching not working right
- Fix plain string matching not being case sensitive

Note that this is a fairly urgent PR because of the fixes in 107bdd4. Plain string matching will throw an error if it find a match currently.

@plorry 
