### PR TITLE
Fix match logging having useless information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ build/Release
 node_modules
 
 settings.js
+/matches.dry-run.json
+/matches.json

--- a/vegassist.js
+++ b/vegassist.js
@@ -17,6 +17,10 @@ var logFile = path.join(__dirname, (isDryRun ? 'matches.dry-run' : 'matches') + 
 
 // log tweets and their matches as json, each tweet/match will be a separate line of json
 var logMatches = function(tweet, matches) {
+    // flatten match objects a bit
+    matches = matches.map(function(match){
+        return {match: match[0], index: match.index, filter: match.filter.toString(), filterList: match.filterList };
+    })
     fs.appendFile(logFile, JSON.stringify({ tweet: tweet, matches: matches }) + "\n");
 }
 


### PR DESCRIPTION
- Make the matching phrase use the key 'match' and strip all the RegExp group matches from the log output
- Fixes #16
- Add log files to .gitignore
