### PR TITLE
Add Portuguese (pt-PT) filters

### DIFF
--- a/filters/portuguese.js
+++ b/filters/portuguese.js
@@ -1,0 +1,5 @@
+module.exports = [
+    /quero (tornar\-me|ser) vegan/gi,
+    /como (me torno|me posso tornar|posso tornar\-me) vegan/gi,
+    /gosta(va|ria) de (ser|me tornar|tornar\-me) vegan/gi,
+];


### PR DESCRIPTION
Hey there!

This PR adds support for a few sentences in Portuguese - 3 versions with a few variations in writing style each.

It's `pt-PT`, but should work decently for Brazillian Portuguese (`pt-BR`).

Cheers! :+1: :seedling: 
