### PR TITLE
Refactor

### DIFF
--- a/filters/dutch.js
+++ b/filters/dutch.js
@@ -1,3 +1,8 @@
+var util = require("../lib/util");
+var track = util.track;
+
+track("vegan", "veganist");
+
 module.exports = [
     'help me veganist te worden',
     'help me vegan te worden',

--- a/filters/english.js
+++ b/filters/english.js
@@ -1,4 +1,9 @@
-var regex = require("../lib/util").regex
+var util = require("../lib/util");
+var regex = util.regex;
+var track = util.track;
+
+track("vegan");
+
 var adverbs = [
     'really', 'totally', 'probably', 'defin[ia]tely', 'absolutely', 'actually',
     'certainly', 'literally', 'legitimately', 'genuinely', 'honestly', 'truly',

--- a/filters/english.js
+++ b/filters/english.js
@@ -1,3 +1,4 @@
+var regex = require("../lib/util").regex
 var adverbs = [
     'really', 'totally', 'probably', 'defin[ia]tely', 'absolutely', 'actually',
     'certainly', 'literally', 'legitimately', 'genuinely', 'honestly', 'truly',
@@ -5,23 +6,14 @@ var adverbs = [
 ];
 var adverbsRegexSet = adverbs.join('|');
 
-var robustRegex = function(regexStr, flags) {
-    flags = flags || 'gi';
-
-    // replace all spaces with a pattern that matches any combination of whitespace and/or periods
-    regexStr = regexStr.replace(/ /g, '([\\s.]+)');
-
-    return new RegExp(regexStr, flags);
-}
-
 module.exports = [
-    robustRegex( "help me (be( a)?|become( a)?|go) #?vegan" ),
-    robustRegex( "i (" + adverbsRegexSet + ")? ?(want to|wanna|would like to) (be( a)?|become( a)?|go) #?vegan" ),
+    regex( "help me (be( a)?|become( a)?|go) #?vegan" ),
+    regex( "i (" + adverbsRegexSet + ")? ?(want to|wanna|would like to) (be( a)?|become( a)?|go) #?vegan" ),
     // forcing this to be at the start of the tweet is a simple hack for excluding things like "don't tell me I should go vegan"
-    robustRegex( "^(i think)? ?i (" + adverbsRegexSet + ")? ?(should) (go|be) #?vegan" ),
-    robustRegex( "i (" + adverbsRegexSet + ")? ?(will|do)? ?(need|want) help (going|becoming( a)?|being( a)?|staying( a)?) #?vegan" ),
-    robustRegex( "i (" + adverbsRegexSet + ")? ?(want to|wanna|would like to|should) (try) (going|becoming( a)?|being( a)?) #?vegan" ),
-    robustRegex( "i('| a)?m (considering|thinking (about|of)|mulling over) (going|becoming( a)?|being( a)?) #?vegan" ),
-    robustRegex( "i (" + adverbsRegexSet + ")? ?(wish) i (was|were) #?vegan" ),
-    robustRegex( "i (can|could) (" + adverbsRegexSet + ")? ?(see|picture|imagine)( myself)? (going|being( a)?|becoming( a)?) #?vegan")
+    regex( "^(i think)? ?i (" + adverbsRegexSet + ")? ?(should) (go|be) #?vegan" ),
+    regex( "i (" + adverbsRegexSet + ")? ?(will|do)? ?(need|want) help (going|becoming( a)?|being( a)?|staying( a)?) #?vegan" ),
+    regex( "i (" + adverbsRegexSet + ")? ?(want to|wanna|would like to|should) (try) (going|becoming( a)?|being( a)?) #?vegan" ),
+    regex( "i('| a)?m (considering|thinking (about|of)|mulling over) (going|becoming( a)?|being( a)?) #?vegan" ),
+    regex( "i (" + adverbsRegexSet + ")? ?(wish) i (was|were) #?vegan" ),
+    regex( "i (can|could) (" + adverbsRegexSet + ")? ?(see|picture|imagine)( myself)? (going|being( a)?|becoming( a)?) #?vegan")
 ]

--- a/filters/portuguese.js
+++ b/filters/portuguese.js
@@ -1,3 +1,8 @@
+var util = require("../lib/util");
+var track = util.track;
+
+track("vegan");
+
 module.exports = [
     /quero (tornar\-me|ser) vegan/gi,
     /como (me torno|me posso tornar|posso tornar\-me) vegan/gi,

--- a/filters/spanish.js
+++ b/filters/spanish.js
@@ -1,3 +1,8 @@
+var util = require("../lib/util");
+var track = util.track;
+
+track("vegana");
+
 module.exports = [
   "quisiera ser vegana",
   "quiero ser vegana",

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,22 +1,36 @@
 var fs = require('fs');
 var path = require('path');
 
-var TweetFilter = function(filter_dir, excluded_terms) {
-    this.filters = this.loadFilters(filter_dir);
+var TweetFilter = function(filters_or_dirpath, excluded_terms) {
+    if (typeof filters_or_dirpath === "string") {
+        this.filters = TweetFilter.getFiltersFromDirectory(filters_or_dirpath);
+    } else {
+        this.filters = filters_or_dirpath;
+    }
     this.excluded_terms = excluded_terms || [];
 }
 
 // load all files from a directory and use their exports as filters
 // the files should export arrays of strings/regex expressions
-TweetFilter.prototype.loadFilters = function(dir) {
+TweetFilter.getFiltersFromDirectory = function(dir) {
     dir = path.resolve(dir);
-    var filters = {};
     var filter_files = fs.readdirSync(dir);
-    filter_files.forEach(function(filter_file) {
+    var joined_files = [];
+    filter_files.forEach(function(file) {
+        joined_files.push(path.join(dir, file));
+    })
+    return TweetFilter.getFiltersFromFiles.apply(this, joined_files);
+}
+
+// load the file(s) and use its/their exports as filters
+// the file should export arrays of strings/regex expressions
+TweetFilter.getFiltersFromFiles = function() {
+    var filters = {};
+    for (var i = 0; i < arguments.length; i++) {
+        var filter_file = path.resolve(arguments[i]);
         var filter_name = path.basename(filter_file, path.extname(filter_file));
-        var filter = require(path.join(dir, filter_file));
-        filters[filter_name] = filter;
-    });
+        filters[filter_name] = require(filter_file);
+    }
     return filters;
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,10 @@
+const util = exports
+
+util.regex = function(regexStr, flags) {
+    flags = flags || 'gi';
+
+    // replace all spaces with a pattern that matches any combination of whitespace and/or periods
+    regexStr = regexStr.replace(/ /g, '([\\s.]+)');
+
+    return new RegExp(regexStr, flags);
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -8,3 +8,33 @@ util.regex = function(regexStr, flags) {
 
     return new RegExp(regexStr, flags);
 }
+
+util.trackedTerms = [];
+var trackedTerms = util.trackedTerms;
+
+var isInArray = function(array, element) {
+    return array.indexOf(element) > -1;
+}
+
+util.track = function() {
+    for (var i = 0; i < arguments.length; i++) {
+        var phrase = arguments[i].toLowerCase();
+        if (!isInArray(trackedTerms, phrase)) {
+            trackedTerms.push(phrase);
+        }
+    }
+}
+
+util.untrack = function() {
+    for (var i = 0; i < arguments.length; i++) {
+        var phrase = arguments[i].toLowerCase();
+        var index = trackedTerms.indexOf(phrase);
+        if (index > -1) {
+            trackedTerms.splice(index);
+        }
+    }
+}
+
+util.untrackAll = function() {
+    trackedTerms.length = 0;
+}

--- a/test/lib/shared.js
+++ b/test/lib/shared.js
@@ -1,0 +1,11 @@
+exports.testMatches = function(test, matches, filter) {
+    matches.forEach(function(match) {
+        test.ok(filter.matches(match), "'" + match + "' should match");    
+    })
+}
+
+exports.testFalsePositives = function(test, falsePositives, filter) {
+    falsePositives.forEach(function(falsePositive) {
+        test.ok(!filter.matches(falsePositive), "'" + falsePositive + "' should not match");
+    })
+}

--- a/test/test-dutch.js
+++ b/test/test-dutch.js
@@ -1,0 +1,22 @@
+var shared = require('./lib/shared');
+var TweetFilter = require('../lib/filter')
+var filter = new TweetFilter(TweetFilter.getFiltersFromFiles("filters/dutch"))
+
+var matches = [
+    "something Dutch ik wil veganist worden something else",
+    "\"Dutch slogan\" ik wil veganist zijn",
+    "help me veganist te worden",
+];
+
+var falsePositives = [
+];
+
+exports.matches = function(test) {
+    shared.testMatches(test, matches, filter);
+    test.done();
+}
+
+exports.falsePositives = function(test) {
+    shared.testFalsePositives(test, falsePositives, filter);
+    test.done();
+}

--- a/test/test-english.js
+++ b/test/test-english.js
@@ -1,0 +1,71 @@
+var shared = require('./lib/shared');
+var TweetFilter = require('../lib/filter')
+var filter = new TweetFilter(TweetFilter.getFiltersFromFiles("filters/english"))
+
+var matches = [
+    'help me go vegan',
+    'help me become vegan',
+    'help me be vegan',
+    'i want to go vegan',
+    'i want to become vegan',
+    'i want to be vegan',
+    'i wanna go vegan',
+    'i wanna be vegan',
+    "I would like to go vegan",
+    "I want to be a vegan",
+    "I wanna become vegan",
+    "I wanna be a vegan",
+    "I really wanna be vegan",
+    "I should go vegan",
+    "I probably should go vegan",
+    "I need help going vegan",
+    "I want help going vegan",
+    "I really need help staying vegan",
+    "I think that i want to go vegan",
+    "I think i should go vegan",
+    "i will need help going vegan",
+    "i do need help going vegan",
+    "i definitely want to go vegan",
+    "i definately want to go vegan",
+    "i honestly would like to go vegan",
+    "i truly want to try going vegan",
+    "i wanna try becoming a vegan",
+    "i'm thinking about going vegan",
+    "i'm thinking of going vegan",
+    "im thinking about becoming vegan",
+    "i am considering being a vegan",
+    "i'm mulling over becoming vegan",
+    "i want to go #vegan",
+    "i. want. to. go. vegan.",
+    "i.. want  to go ... vegan",
+    "i wish i was vegan",
+    "i wish i were vegan",
+    "i can see myself becoming a vegan someday",
+    "i could definitely picture myself going vegan",
+    "\"i like to quote\" but i want to go vegan and \"stuff\"",
+];
+
+var falsePositives = [
+    "I do not want to go vegan",
+    "I should be a vegan", // this phrasing more than likely isn't about going vegan long-term (e.g. I should be a vegan for Halloween)
+    "Don't tell me I should go vegan",
+    "\"I want to go vegan\"",
+    "\"stuff\" \"I want to go vegan\" \"stuff\"",
+    "\"stuff\" \" I want to go vegan \" \"stuff\"",
+    "\"unbalanced\"\" but i want to go vegan and \"quotes\"",
+];
+
+exports.matches = function(test) {
+    shared.testMatches(test, matches, filter);
+    test.done();
+}
+
+exports.falsePositives = function(test) {
+    shared.testFalsePositives(test, falsePositives, filter);
+    // matching phrases with the word 'vegetarian' subbed for 'vegan' should not match
+    matches.forEach(function(match) {
+        var falsePositive = match.replace(/vegan/g, 'vegetarian');
+        test.ok(!filter.matches(falsePositive), "'" + falsePositive + "' should not match");
+    })
+    test.done();
+}

--- a/test/test-filter.js
+++ b/test/test-filter.js
@@ -1,118 +1,8 @@
 var TweetFilter = require('../lib/filter.js')
-var filter = new TweetFilter('filters', ['excludeme'])
-
-var matchesEng = [
-    'help me go vegan',
-    'help me become vegan',
-    'help me be vegan',
-    'i want to go vegan',
-    'i want to become vegan',
-    'i want to be vegan',
-    'i wanna go vegan',
-    'i wanna be vegan',
-    "I would like to go vegan",
-    "I want to be a vegan",
-    "I wanna become vegan",
-    "I wanna be a vegan",
-    "I really wanna be vegan",
-    "I should go vegan",
-    "I probably should go vegan",
-    "I need help going vegan",
-    "I want help going vegan",
-    "I really need help staying vegan",
-    "I think that i want to go vegan",
-    "I think i should go vegan",
-    "i will need help going vegan",
-    "i do need help going vegan",
-    "i definitely want to go vegan",
-    "i definately want to go vegan",
-    "i honestly would like to go vegan",
-    "i truly want to try going vegan",
-    "i wanna try becoming a vegan",
-    "i'm thinking about going vegan",
-    "i'm thinking of going vegan",
-    "im thinking about becoming vegan",
-    "i am considering being a vegan",
-    "i'm mulling over becoming vegan",
-    "i want to go #vegan",
-    "i. want. to. go. vegan.",
-    "i.. want  to go ... vegan",
-    "i wish i was vegan",
-    "i wish i were vegan",
-    "i can see myself becoming a vegan someday",
-    "i could definitely picture myself going vegan",
-    "\"i like to quote\" but i want to go vegan and \"stuff\"",
-];
-
-var falsePositivesEng = [
-    "I do not want to go vegan",
-    "I should be a vegan", // this phrasing more than likely isn't about going vegan long-term (e.g. I should be a vegan for Halloween)
-    "Don't tell me I should go vegan",
-    "\"I want to go vegan\"",
-    "\"stuff\" \"I want to go vegan\" \"stuff\"",
-    "\"stuff\" \" I want to go vegan \" \"stuff\"",
-    "\"unbalanced\"\" but i want to go vegan and \"quotes\"",
-];
-
-var matchesDut = [
-    "something Dutch ik wil veganist worden something else",
-    "\"Dutch slogan\" ik wil veganist zijn",
-    "help me veganist te worden"
-];
-
-var matchesSpa = [
-    "hi i am spanish and Quisiera Ser Vegana",
-    "quisiera hacerme vegana they tell me",
-    "i also think that quiero hacerme vegana is something else I say"
-];
-
-var matchesPor = [
-    "hey look at this, como me torno vegan",
-    "Gostava de ser vegan is what I gotta tell you",
-    "Como me posso tornar vegan",
-    "tell me gostaria de Me tornar vegan or what?"
-];
-
-var matchTest = function(matchList, test) {
-    matchList.forEach(function(match) {
-        test.ok(filter.matches(match), "'" + match + "' should match");    
-    })
-};
-
-exports.matchesEng = function(test) {
-    matchTest(matchesEng, test);
-    test.done();
-}
-
-exports.falsePositivesEng = function(test) {
-    falsePositivesEng.forEach(function(falsePositive) {
-        test.ok(!filter.matches(falsePositive), "'" + falsePositive + "' should not match");
-    })
-    // matching phrases with the word 'vegetarian' subbed for 'vegan' should not match
-    matchesEng.forEach(function(match) {
-        var falsePositive = match.replace(/vegan/g, 'vegetarian');
-        test.ok(!filter.matches(falsePositive), "'" + falsePositive + "' should not match");
-    })
-    test.done();
-}
-
-exports.matchesDut = function(test) {
-    matchTest(matchesDut, test);
-    test.done();  
-}
-
-exports.matchesSpa = function(test) {
-    matchTest(matchesSpa, test);
-    test.done();
-}
-
-exports.matchesPor = function(test) {
-    matchTest(matchesPor, test);
-    test.done();
-}
+var filter = new TweetFilter({test: ['test']}, ['excludeme'])
 
 exports.retweetedByMe = function(test) {
-    var retweetedTweet = {retweeted: true, text: "I want to go vegan", user: {description: "", name: "", screen_name: ""}};
+    var retweetedTweet = {retweeted: true, text: "test", user: {description: "", name: "", screen_name: ""}};
     test.ok(!filter.matches(retweetedTweet), "Filter should not match tweets that have been retweeted by the authed user");
     retweetedTweet.retweeted = false;
     test.ok(filter.matches(retweetedTweet), "Filter should match tweets that haven't been retweeted by the authed user");
@@ -120,7 +10,7 @@ exports.retweetedByMe = function(test) {
 }
 
 exports.retweet = function(test) {
-    var retweetTweet = {retweeted: false, retweeted_status: {}, text: "I want to go vegan", user: {description: "", name: "", screen_name: ""}};
+    var retweetTweet = {retweeted: false, retweeted_status: {}, text: "test", user: {description: "", name: "", screen_name: ""}};
     test.ok(!filter.matches(retweetTweet), "Filter should not match tweets that are retweets");
     delete retweetTweet.retweeted_status;
     test.ok(filter.matches(retweetTweet), "Filter should match tweets that aren't retweets");
@@ -128,20 +18,20 @@ exports.retweet = function(test) {
 }
 
 exports.reply = function(test) {
-    var replyTweet = {retweeted: false, text: "@someone I want to go vegan", user: {description: "", name: "", screen_name: ""}};
+    var replyTweet = {retweeted: false, text: "@someone test", user: {description: "", name: "", screen_name: ""}};
     test.ok(!filter.matches(replyTweet), "Filter should not match @reply tweets");
-    replyTweet.text = "I want to go vegan";
+    replyTweet.text = "test";
     test.ok(filter.matches(replyTweet), "Filter should match tweets that aren't @replies");
     test.done();
 }
 
 exports.excludedTerms = function(test) {
-    var unexcludedTweet = {retweeted: false, text: "I want to go vegan", user: {description: "", name: "", screen_name: ""}};
+    var unexcludedTweet = {retweeted: false, text: "test", user: {description: "", name: "", screen_name: ""}};
     test.ok(filter.matches(unexcludedTweet), "Filter should match tweets that don't have any excluded terms in their bio/name/username");
 
-    var excludedBioTweet = {retweeted: false, text: "I want to go vegan", user: {description: "Something and excludeme", name: "", screen_name: ""}};
-    var excludedNameTweet = {retweeted: false, text: "I want to go vegan", user: {description: "", name: "EXCLUDEME", screen_name: ""}};
-    var excludedScreenNameTweet = {retweeted: false, text: "I want to go vegan", user: {description: "", name: "", screen_name: "excludeme"}};
+    var excludedBioTweet = {retweeted: false, text: "test", user: {description: "Something and excludeme", name: "", screen_name: ""}};
+    var excludedNameTweet = {retweeted: false, text: "test", user: {description: "", name: "EXCLUDEME", screen_name: ""}};
+    var excludedScreenNameTweet = {retweeted: false, text: "test", user: {description: "", name: "", screen_name: "excludeme"}};
 
     test.ok(!filter.matches(excludedBioTweet), "Filter should not match tweets from users with excluded terms in their bio");
     test.ok(!filter.matches(excludedNameTweet), "Filter should not match tweets from users with excluded terms in their name");

--- a/test/test-portuguese.js
+++ b/test/test-portuguese.js
@@ -1,0 +1,23 @@
+var shared = require('./lib/shared');
+var TweetFilter = require('../lib/filter')
+var filter = new TweetFilter(TweetFilter.getFiltersFromFiles("filters/portuguese"))
+
+var matches = [
+    "hey look at this, como me torno vegan",
+    "Gostava de ser vegan is what I gotta tell you",
+    "Como me posso tornar vegan",
+    "tell me gostaria de Me tornar vegan or what?",
+];
+
+var falsePositives = [
+];
+
+exports.matches = function(test) {
+    shared.testMatches(test, matches, filter);
+    test.done();
+}
+
+exports.falsePositives = function(test) {
+    shared.testFalsePositives(test, falsePositives, filter);
+    test.done();
+}

--- a/test/test-spanish.js
+++ b/test/test-spanish.js
@@ -1,0 +1,22 @@
+var shared = require('./lib/shared');
+var TweetFilter = require('../lib/filter')
+var filter = new TweetFilter(TweetFilter.getFiltersFromFiles("filters/spanish"))
+
+var matches = [
+    "hi i am spanish and Quisiera Ser Vegana",
+    "quisiera hacerme vegana they tell me",
+    "i also think that quiero hacerme vegana is something else I say",
+];
+
+var falsePositives = [
+];
+
+exports.matches = function(test) {
+    shared.testMatches(test, matches, filter);
+    test.done();
+}
+
+exports.falsePositives = function(test) {
+    shared.testFalsePositives(test, falsePositives, filter);
+    test.done();
+}

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -1,0 +1,10 @@
+var util = require('../lib/util.js')
+
+exports.regexSpaces = function(test) {
+    // set the flags without global so that lastIndex does not get moved on each RegExp.test call
+    var testRegex = util.regex("a b c", "i");
+    test.ok(testRegex.test("a b c"), "Should match the exact string");
+    test.ok(testRegex.test("a  b  \t c"), "Spaces should match any whitespace");
+    test.ok(testRegex.test("a . b ... \t c"), "Spaces should match any combination of whitespace and periods");
+    test.done();
+}

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -8,3 +8,26 @@ exports.regexSpaces = function(test) {
     test.ok(testRegex.test("a . b ... \t c"), "Spaces should match any combination of whitespace and periods");
     test.done();
 }
+
+exports.tracking = function(test) {
+    util.untrackAll();
+    test.deepEqual([], util.trackedTerms, "Should start with an empty array");
+    util.track("test");
+    test.deepEqual(["test"], util.trackedTerms, "track should add the phrase");
+    util.untrack("test");
+    test.deepEqual([], util.trackedTerms, "untrack should remove the phrase");
+    util.track("test");
+    util.track("test");
+    test.deepEqual(["test"], util.trackedTerms, "Duplicates should be discarded");
+    util.track("TEst");
+    test.deepEqual(["test"], util.trackedTerms, "Duplicates should be case insensitive");
+    util.track("other");
+    test.deepEqual(["test", "other"], util.trackedTerms, "Should support multiple phrases");
+    util.track("other", "another", "third");
+    test.deepEqual(["test", "other", "another", "third"], util.trackedTerms, "track should support multiple parameters");
+    util.untrack("other", "another", "third");
+    test.deepEqual(["test"], util.trackedTerms, "untrack should support multiple parameters");
+    util.untrackAll();
+    test.deepEqual([], util.trackedTerms, "untrackAll should empty the array");
+    test.done();
+}

--- a/vegassist.js
+++ b/vegassist.js
@@ -7,10 +7,10 @@ var fs = require('fs');
 
 // Declare your own Twitter app credentials here, if duplicating
 var T = new Twit(settings.CREDS);
-// Whenever the Twitter stream notifies us of a new Tweet with the term 'vegan' (or its international equivalents), we handle it!
-var stream = T.stream('statuses/filter', { track: util.trackedTerms });
 // Load filters from all files in the filters directory
 var filter = new TweetFilter('filters', settings.FILTERED_TERMS);
+// Whenever the Twitter stream notifies us of a new Tweet with the term 'vegan' (or its international equivalents), we handle it!
+var stream = T.stream('statuses/filter', { track: util.trackedTerms });
 // Run with option '--dry-run' to disable retweeting and instead log matches to console
 var isDryRun = process.argv[2] === '--dry-run';
 // Use a different log file for dry-run

--- a/vegassist.js
+++ b/vegassist.js
@@ -1,13 +1,14 @@
 var Twit = require('twit');
 var settings = require('./settings.js');
 var TweetFilter = require('./lib/filter');
+var util = require('./lib/util');
 var path = require('path');
 var fs = require('fs');
 
 // Declare your own Twitter app credentials here, if duplicating
 var T = new Twit(settings.CREDS);
 // Whenever the Twitter stream notifies us of a new Tweet with the term 'vegan' (or its international equivalents), we handle it!
-var stream = T.stream('statuses/filter', { track: ['vegan', 'veganist', 'vegana'] });
+var stream = T.stream('statuses/filter', { track: util.trackedTerms });
 // Load filters from all files in the filters directory
 var filter = new TweetFilter('filters', settings.FILTERED_TERMS);
 // Run with option '--dry-run' to disable retweeting and instead log matches to console

--- a/vegassist.js
+++ b/vegassist.js
@@ -31,6 +31,8 @@ var logMatches = function(tweet, matches) {
     fs.appendFile(logFile, JSON.stringify({ tweet: tweet, matches: matches }) + "\n", function(){});
 }
 
+console.log("Tracking terms: " + util.trackedTerms.join(", "));
+
 stream.on('connect', function (response) {
     console.log("Connecting to Twitter..." + (isDryRun ? " (dry run, will not retweet matches)" : ""))
 })


### PR DESCRIPTION
No functionality should have changed, just a lot of moving stuff around. See the commit log for the details. The only functionality that was added was the tracked terms being output to the console on startup.

Note that the way I implemented moving the tracked terms into the language files is kind of hacky, as it will bug out in certain situations due to the nature of require, but it should work well enough for our purposes--the bot won't run into the bugginess; it'd only show up if we wanted to test that each filter file tracks the correct terms. I didn't want to mess with the exports format we currently have, so I used a slightly weird workaround.
