### PR TITLE
Added patterns for recidivism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,15 @@ node_modules
 settings.js
 /matches.dry-run.json
 /matches.json
+
+# Vim files
+# swap
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~
+# auto-generated tag files
+tags

--- a/filters/english.js
+++ b/filters/english.js
@@ -29,6 +29,6 @@ module.exports = [
 	// stemming recidivism
     regex( "i('| a)?m having a (" + recidivismAdjectivesRegexSet + ") time (staying|being) #?vegan"),
     regex( "i? ?don'?t know how much longer i( can| will|'ll) (stay|be) #?vegan"),
-    regex( "(being)? ?#?vegan('| i)s (too)? ?" + recidivismAdjectivesRegexSet),
-    regex( "((it)?('| i)s)? ?(too)? ?" + recidivismAdjectivesRegexSet + " (to be|being|staying) #?vegan")
+    regex( "(being)? ?#?vegan('| i)s (too)? ?(" + recidivismAdjectivesRegexSet + ")"),
+    regex( "((it)?('| i)s)? ?(too)? ?(" + recidivismAdjectivesRegexSet + ") (to be|being|staying) #?vegan")
 ]

--- a/filters/english.js
+++ b/filters/english.js
@@ -11,6 +11,11 @@ var adverbs = [
 ];
 var adverbsRegexSet = adverbs.join('|');
 
+var recidivismAdjectives = [
+	'hard', 'tough', 'difficult', 'rough'
+];
+var recidivismAdjectivesRegexSet = recidivismAdjectives.join('|');
+
 module.exports = [
     regex( "help me (be( a)?|become( a)?|go) #?vegan" ),
     regex( "i (" + adverbsRegexSet + ")? ?(want to|wanna|would like to) (be( a)?|become( a)?|go) #?vegan" ),
@@ -20,5 +25,10 @@ module.exports = [
     regex( "i (" + adverbsRegexSet + ")? ?(want to|wanna|would like to|should) (try) (going|becoming( a)?|being( a)?) #?vegan" ),
     regex( "i('| a)?m (" + adverbsRegexSet + ")? ?(considering|thinking (about|of)|mulling over|planning on) (going|becoming( a)?|being( a)?) #?vegan" ),
     regex( "i (" + adverbsRegexSet + ")? ?(wish) i (was|were) #?vegan" ),
-    regex( "i (can|could) (" + adverbsRegexSet + ")? ?(see|picture|imagine)( myself)? (going|being( a)?|becoming( a)?) #?vegan")
+    regex( "i (can|could) (" + adverbsRegexSet + ")? ?(see|picture|imagine)( myself)? (going|being( a)?|becoming( a)?) #?vegan"),
+	// stemming recidivism
+    regex( "i('| a)?m having a (" + recidivismAdjectivesRegexSet + ") time (staying|being) #?vegan"),
+    regex( "i? ?don'?t know how much longer i( can| will|'ll) (stay|be) #?vegan"),
+    regex( "(being)? ?#?vegan('| i)s (too)? ?" + recidivismAdjectivesRegexSet),
+    regex( "((it)?('| i)s)? ?(too)? ?" + recidivismAdjectivesRegexSet + " (to be|being|staying) #?vegan")
 ]


### PR DESCRIPTION
Added some regex patterns to find people at risk of falling off the wagon, as per issue 48: https://github.com/plorry/VegAssist/issues/48. Patterns were only added for the english filters.

Also added .swp, .swo and other vim-specific file extensions to the gitignore.
