### PR TITLE
Track tweets that only mention vegassist and nobody else

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ module.exports = {
     access_token_secret:  '...'
   },
   FILTERS: [],
-  HANDLE: '(botname, i.e. vegassist or @vegassist)'
+  HANDLE: 'botname'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ VegAssist tracks usage of the term "vegan" on twitter's public stream, and proce
 1. Clone this repository
 2. Install [node.js and npm](https://nodejs.org)
 3. Run `npm install` in the directory that you cloned this repository into
-4. Create a `settings.js` file with the format below, filling in your Twitter API credentials:
+4. Create a `settings.js` file with the format below, filling in your Twitter API credentials and Twitter botname:
 5. Run `node .`
 
 #### `settings.js` format:
@@ -20,7 +20,8 @@ module.exports = {
     access_token:         '...',
     access_token_secret:  '...'
   },
-  FILTERS: []
+  FILTERS: [],
+  HANDLE: '(botname, i.e. vegassist or @vegassist)'
 }
 ```
 

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -178,11 +178,15 @@ TweetFilter.prototype.tweetContainsExcludedTerms = function(tweet) {
 }
 
 TweetFilter.prototype.tweetIsPrivateConvo = function(tweet) {
-    return tweet.text[0] === '@';
+    return tweet.text[0] === '@' && tweet.text.substr(1, 9) != "vegassist";
+}
+
+TweetFilter.prototype.tweetContainsMultipleMentions = function(tweet) {
+    return tweet.text.split('@').length - 1 > 1; 
 }
 
 TweetFilter.prototype.tweetIsEligable = function(tweet) {
-    return !this.tweetWasRetweetedByMe(tweet) && !this.tweetIsARetweet(tweet) && !this.tweetContainsExcludedTerms(tweet) && !this.tweetIsPrivateConvo(tweet);
+    return !this.tweetWasRetweetedByMe(tweet) && !this.tweetIsARetweet(tweet) && !this.tweetContainsExcludedTerms(tweet) && !this.tweetIsPrivateConvo(tweet) && !this.tweetContainsMultipleMentions(tweet);
 }
 
 // returns an array containing all matches found or false if none were found

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,12 +1,15 @@
 var fs = require('fs');
 var path = require('path');
 
-var TweetFilter = function(filters_or_dirpath, excluded_terms, filters) {
+var TweetFilter = function(filters_or_dirpath, excluded_terms, filters, handle) {
     if (typeof filters_or_dirpath === "string") {
         this.filters = TweetFilter.getFiltersFromDirectory(filters_or_dirpath, filters);
     } else {
         this.filters = filters_or_dirpath;
     }
+	if (handle.length > 0){
+		this.filters.handle = [handle];
+	}
     this.excluded_terms = excluded_terms || [];
 }
 
@@ -177,8 +180,12 @@ TweetFilter.prototype.tweetContainsExcludedTerms = function(tweet) {
     }));
 }
 
+TweetFilter.prototype.tweetMentionsMe = function(tweet) {
+    return tweet.text.toLowerCase().indexOf(this.filters.handle) != -1;
+}
+
 TweetFilter.prototype.tweetIsPrivateConvo = function(tweet) {
-    return tweet.text[0] === '@' && tweet.text.substr(1, 9) != "vegassist";
+    return tweet.text[0] === '@' && !this.tweetMentionsMe(tweet);
 }
 
 TweetFilter.prototype.tweetContainsMultipleMentions = function(tweet) {
@@ -192,9 +199,6 @@ TweetFilter.prototype.tweetIsEligable = function(tweet) {
 // returns an array containing all matches found or false if none were found
 TweetFilter.prototype.matches = function(tweet_or_text) {
     var isTweet = typeof tweet_or_text !== 'string'
-
-    if (isTweet && !this.tweetIsEligable(tweet_or_text))
-        return false;
 
     var text = !isTweet ? tweet_or_text : tweet_or_text.text;
     var matches = this.getMatchesForAllFilters(text).filter(function(match) {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -181,7 +181,7 @@ TweetFilter.prototype.tweetContainsExcludedTerms = function(tweet) {
 }
 
 TweetFilter.prototype.tweetMentionsMe = function(tweet) {
-    return tweet.text.toLowerCase().indexOf(this.filters.handle) != -1;
+    return tweet.text.toLowerCase().indexOf(this.filters.handle[0]) != -1;
 }
 
 TweetFilter.prototype.tweetIsPrivateConvo = function(tweet) {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -200,6 +200,9 @@ TweetFilter.prototype.tweetIsEligable = function(tweet) {
 TweetFilter.prototype.matches = function(tweet_or_text) {
     var isTweet = typeof tweet_or_text !== 'string'
 
+	if (isTweet && !this.tweetIsEligable(tweet_or_text))
+        return false;
+
     var text = !isTweet ? tweet_or_text : tweet_or_text.text;
     var matches = this.getMatchesForAllFilters(text).filter(function(match) {
         var isQuoted = TweetFilter.isPhraseQuoted(match[0], match.index, text);

--- a/lib/util.js
+++ b/lib/util.js
@@ -56,5 +56,3 @@ util.untrack = function() {
 util.untrackAll = function() {
     trackedTerms.length = 0;
 }
-
-util.track("vegassist");

--- a/lib/util.js
+++ b/lib/util.js
@@ -56,3 +56,5 @@ util.untrack = function() {
 util.untrackAll = function() {
     trackedTerms.length = 0;
 }
+
+util.track("vegassist");

--- a/vegassist.js
+++ b/vegassist.js
@@ -12,7 +12,15 @@ var DELAYTIME = 1000 * 60 * 2;
 // Load filters from all files in the filters directory
 var settingsFilteredTerms = settings.FILTERED_TERMS || [];
 var settingsFilters = settings.FILTERS || [];
-var filter = new TweetFilter('filters', settingsFilteredTerms, settingsFilters);
+
+var handle = settings.HANDLE || "";
+if (handle.length > 0){
+	if (handle.indexOf('@') != 0)
+		handle = '@' + handle;
+	util.track(handle);
+}
+
+var filter = new TweetFilter('filters', settingsFilteredTerms, settingsFilters, handle);
 // Whenever the Twitter stream notifies us of a new Tweet with the term 'vegan' (or its international equivalents), we handle it!
 var stream = T.stream('statuses/filter', { track: util.trackedTerms });
 // Run with option '--dry-run' to disable retweeting and instead log matches to console

--- a/vegassist.js
+++ b/vegassist.js
@@ -8,13 +8,15 @@ var fs = require('fs');
 // Declare your own Twitter app credentials here, if duplicating
 var T = new Twit(settings.CREDS);
 // Set a delay time constant of 2 minutes - RTs will be delayed by this amount
-var DELAYTIME = 1000 * 60 * 2;
+//var DELAYTIME = 1000 * 60 * 2;
+var DELAYTIME = 1000;
 // Load filters from all files in the filters directory
 var settingsFilteredTerms = settings.FILTERED_TERMS || [];
 var settingsFilters = settings.FILTERS || [];
 var filter = new TweetFilter('filters', settingsFilteredTerms, settingsFilters);
 // Whenever the Twitter stream notifies us of a new Tweet with the term 'vegan' (or its international equivalents), we handle it!
 var stream = T.stream('statuses/filter', { track: util.trackedTerms });
+console.log(util.trackedTerms);
 // Run with option '--dry-run' to disable retweeting and instead log matches to console
 var isDryRun = process.argv[2] === '--dry-run';
 // Use a different log file for dry-run

--- a/vegassist.js
+++ b/vegassist.js
@@ -8,15 +8,13 @@ var fs = require('fs');
 // Declare your own Twitter app credentials here, if duplicating
 var T = new Twit(settings.CREDS);
 // Set a delay time constant of 2 minutes - RTs will be delayed by this amount
-//var DELAYTIME = 1000 * 60 * 2;
-var DELAYTIME = 1000;
+var DELAYTIME = 1000 * 60 * 2;
 // Load filters from all files in the filters directory
 var settingsFilteredTerms = settings.FILTERED_TERMS || [];
 var settingsFilters = settings.FILTERS || [];
 var filter = new TweetFilter('filters', settingsFilteredTerms, settingsFilters);
 // Whenever the Twitter stream notifies us of a new Tweet with the term 'vegan' (or its international equivalents), we handle it!
 var stream = T.stream('statuses/filter', { track: util.trackedTerms });
-console.log(util.trackedTerms);
 // Run with option '--dry-run' to disable retweeting and instead log matches to console
 var isDryRun = process.argv[2] === '--dry-run';
 // Use a different log file for dry-run


### PR DESCRIPTION
Done is response to https://github.com/plorry/VegAssist/issues/29. This will hook a twitter handle into the existing filter system and check it the same way it checks all other filters. It ignores tweets with multiple mentions in order to cull people replying to retweets.

The handle can be set in the settings file, as reflected in the update readme.

Tests run:
1. "@vegassist i wanna go vegan" - gets retweeted.
2. "@vegassist @shaderboy i wanna go vegan" - doesn't get retweeted.
3. "@vegassist test" - gets retweeted.
