### PR TITLE
update recidivism phrases

### DIFF
--- a/filters/english.js
+++ b/filters/english.js
@@ -29,6 +29,6 @@ module.exports = [
 	// stemming recidivism
     regex( "i('| a)?m having a (" + recidivismAdjectivesRegexSet + ") time (staying|being) #?vegan"),
     regex( "i? ?don'?t know how much longer i( can| will|'ll) (stay|be) #?vegan"),
-    regex( "(being)? ?#?vegan('| i)s (too)? ?(" + recidivismAdjectivesRegexSet + ")"),
-    regex( "((it)?('| i)s)? ?(too)? ?(" + recidivismAdjectivesRegexSet + ") (to be|being|staying) #?vegan")
+    regex( "(being|staying|going) ?#?vegan('| i)s (too)? ?(" + recidivismAdjectivesRegexSet + ")"),
+    regex( "it(('| i)s)? ?(too)? ?(" + recidivismAdjectivesRegexSet + ") (to be( a)?|being( a)?|staying( a)?|going) #?vegan")
 ]


### PR DESCRIPTION
a few false positives so far with recidivism phrases.
eg.: https://twitter.com/JUSTABLACKGUYY/status/775400993768996864
which falls somewhere outside of the scope of the bot
made a few terms required, to prevent matching on 2nd/3rd-person references.
